### PR TITLE
Fixed ontology term annotation bug.

### DIFF
--- a/application/Model/OntologyModel.php
+++ b/application/Model/OntologyModel.php
@@ -952,6 +952,8 @@ class OntologyModel {
 		foreach ( $related as $termIRI => $termClass ) {
 			if ( isset( $labels[$termIRI] ) ) {
 				$termClass->label = array_shift( $labels[$termIRI] );
+			} else {
+				$termClass->label = $termIRI;
 			}
 		}
 		return $related;


### PR DESCRIPTION
Fixed for annotation which is URL/IRI, the label display will be chopped. Using http://purl.obolibrary.org/obo/RO_0002507 as an example, if the value of an annotation is http://www.ncbi.nlm.nih.gov/pubmed/24330602, the dispaly value will be chopped into 24330602 instead of full URL.